### PR TITLE
If URI is not a regex pattern then always sanitise

### DIFF
--- a/services/RedirectmanagerService.php
+++ b/services/RedirectmanagerService.php
@@ -37,7 +37,7 @@ class RedirectmanagerService extends BaseApplicationComponent
 			// Regex / wildcard match
 			if(preg_match("/^#(.+)#$/", $record['uri'], $matches)){
 				// no-op: all set to use the regex
-			}elseif(strpos($record['uri'], "*")){
+			}else{
 				// not necessary to replace / with \/ here, but no harm to it either
 				$record['uri'] = "#^".str_replace(array("*","/"), array("(.*)", "\/"), $record['uri']).'#';
 			}


### PR DESCRIPTION
This fixes the issue of the CMS crashing in Dev mode if the URI is not a regular expression pattern.

Relates to #5.
