### PR TITLE
Disable redirects when using Live Preview

### DIFF
--- a/RedirectmanagerPlugin.php
+++ b/RedirectmanagerPlugin.php
@@ -31,8 +31,8 @@ class RedirectmanagerPlugin extends BasePlugin
 
 	public function init()
 	{
-		// redirects only take place out of the CP
-		if(craft()->request->isSiteRequest()){
+		// redirects only take place out of the CP (and should not happen in live preview)
+		if(craft()->request->isSiteRequest() && !craft()->request->isLivePreview()){
 			$path = craft()->request->getPath();
 			if( $location = craft()->redirectmanager->processRedirect($path) )
 			{


### PR DESCRIPTION
@rkingon 

We noticed that if you are trying use the Live Preview feature on an entry that is matched in a redirect, the Live Preview feature won't work properly (the Live Preview pulls in the redirect target, not the source entry).

By adding an additional check in the init method, this turns off redirecting if being accessed via Live Preview (which I feel is in the spirit of the existing check)