### PR TITLE
include querystring in path if one exists

### DIFF
--- a/RedirectmanagerPlugin.php
+++ b/RedirectmanagerPlugin.php
@@ -34,6 +34,10 @@ class RedirectmanagerPlugin extends BasePlugin
 		// redirects only take place out of the CP (and should not happen in live preview)
 		if(craft()->request->isSiteRequest() && !craft()->request->isLivePreview()){
 			$path = craft()->request->getPath();
+			if (craft()->request->getQueryString())
+			{
+				$path = $path . '?' . craft()->request->getQueryString();
+			}
 			if( $location = craft()->redirectmanager->processRedirect($path) )
 			{
 				header("Location: ".$location['url'], true, $location['type']);


### PR DESCRIPTION
Fairly simple fix... Check if there's a querystring included in the request and add it to `$path` if there is.

Not a hugely elegant solution, but the logic within `processRedirect($path)` remains the same.

I've got it working on a live site here: http://sypro.co.uk/news?id=18