### PR TITLE
Break after finding a redirectLocation

### DIFF
--- a/redirectmanager/services/RedirectManagerService.php
+++ b/redirectmanager/services/RedirectManagerService.php
@@ -43,12 +43,14 @@ class RedirectManagerService extends BaseApplicationComponent
 			if ($regex_match) {
 				if(preg_match($record['uri'], $uri)){
 					$redirectLocation = preg_replace($record['uri'], $record['location'], $uri);
+					break;
 				}
 			} else {
 				// Standard match
 				if ($record['uri'] == $uri)
 				{
 					$redirectLocation = $record['location'];
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
Currently this foreach loop will always go through ALL redirects. This means that the calculation for whether or not to prepend the site URL to the redirect is based on the LAST record, not the record corresponding to the redirect that was found. The redirect type could also be incorrect because of this.

I think this should resolve an issue we're having where external redirects are getting the siteUrl prepended to them. Let me know if you see any issues with this solution.

Thanks!
John