### PR TITLE
Fix error triggered via commands run via console.

### DIFF
--- a/redirectmanager/RedirectManagerPlugin.php
+++ b/redirectmanager/RedirectManagerPlugin.php
@@ -32,7 +32,7 @@ class RedirectManagerPlugin extends BasePlugin
 	public function init()
 	{
 		// redirects only take place out of the CP
-		if(craft()->request->isSiteRequest() && !craft()->request->isLivePreview())
+		if(craft()->request->isSiteRequest() && !craft()->request->isLivePreview() && !craft()->isConsole())
 		{
 			// only init if it's a legit 404
 			craft()->onException = function(\CExceptionEvent $event)


### PR DESCRIPTION
When running a console command, I stumbled upon this error...

    PHP Error[8]: Undefined index: SERVER_NAME
        in file /var/www/foobar/craft/app/framework/web/CHttpRequest.php at line 352
    #0 /var/www/foobar/craft/app/etc/console/ConsoleApp.php(265): Craft\ConsoleApp->handleError()
    #1 /var/www/foobar/craft/app/framework/web/CHttpRequest.php(352): Craft\ConsoleApp->handleError()
    #2 /var/www/foobar/craft/app/services/ConfigService.php(420): Craft\HttpRequestService->getHostInfo()
    #3 /var/www/foobar/craft/app/etc/web/UrlManager.php(80): Craft\ConfigService->usePathInfo()
    #4 /var/www/foobar/craft/app/framework/base/CModule.php(394): Craft\UrlManager->init()
    #5 /var/www/foobar/craft/app/etc/console/ConsoleApp.php(220): Craft\ConsoleApp->getComponent()
    #6 /var/www/foobar/craft/app/framework/base/CModule.php(103): Craft\ConsoleApp->getComponent()
    #7 /var/www/foobar/craft/app/services/HttpRequestService.php(1163): Craft\ConsoleApp->__get()
    #8 /var/www/foobar/craft/plugins/redirectmanager/RedirectManagerPlugin.php(43): Craft\HttpRequestService->getQueryStringWithoutPath()
    #9 /var/www/foobar/craft/app/services/PluginsService.php(150): Craft\RedirectManagerPlugin->init()
    #10 /var/www/foobar/craft/app/etc/console/ConsoleApp.php(86): Craft\PluginsService->loadPlugins()
    #11 /var/www/foobar/craft/app/framework/base/CApplication.php(170): Craft\ConsoleApp->init()
    #12 /var/www/foobar/craft/app/framework/YiiBase.php(121): Craft\ConsoleApp->__construct()
    #13 /var/www/foobar/craft/app/etc/console/yiic.php(86): createApplication()
    #14 /var/www/foobar/utils/yiic_frontend.php(24): require()

This patch fixes the issue.